### PR TITLE
add multiple embeddings; text block window

### DIFF
--- a/src/index/vespa_.py
+++ b/src/index/vespa_.py
@@ -16,13 +16,17 @@ from typing import (
 from cloudpathlib import S3Path
 from cpr_data_access.parser_models import ParserOutput, PDFTextBlock, VerticalFlipError
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, wait_exponential, stop_after_attempt
+from tenacity import (
+    retry,
+    wait_exponential,
+    stop_after_attempt,
+)
 from vespa.application import Vespa
 from vespa.io import VespaResponse
 
 
 from src import config
-from src.utils import filter_on_block_type, read_npy_file
+from src.utils import filter_on_block_type, read_npy_file, get_text_from_text_block
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,11 +73,15 @@ class VespaDocumentPassage(BaseModel):
     search_weights_ref: str
     family_document_ref: str
     text_block: str
+    text_block_window: str
     text_block_id: str
     text_block_type: str
     text_block_page: Optional[Annotated[int, Field(ge=0)]] = None
     text_block_coords: Optional[TextCoords] = None
-    text_embedding: Annotated[list[float], 768]
+    text_embedding_bge_small: Annotated[list[float], 384]
+    text_embedding_bge_base: Annotated[list[float], 768]
+    text_embedding_distilbert_base_tas_b: Annotated[list[float], 768]
+    text_embedding_distilbert_dot_v5: Annotated[list[float], 768]
 
 
 class VespaFamilyDocument(BaseModel):
@@ -104,63 +112,71 @@ class VespaFamilyDocument(BaseModel):
 
 
 def build_vespa_family_document(
-        task,
-        embeddings,
-        search_weights_ref,
-    ) -> VespaFamilyDocument:
+    task,
+    embeddings,
+    search_weights_ref,
+) -> VespaFamilyDocument:
     return VespaFamilyDocument(
-            search_weights_ref=search_weights_ref,
-            family_name=task.document_name,
-            family_name_index=task.document_name,
-            family_description=task.document_description,
-            family_description_index=task.document_description,
-            family_description_embedding=embeddings[0].tolist(),
-            family_import_id=task.document_metadata.family_import_id,
-            family_slug=task.document_metadata.family_slug,
-            family_publication_ts=task.document_metadata.publication_ts.isoformat(),
-            family_publication_year=task.document_metadata.publication_ts.year,
-            family_category=task.document_metadata.category,
-            family_geography=task.document_metadata.geography,
-            family_source=task.document_metadata.source,
-            document_import_id=task.document_id,
-            document_slug=task.document_slug,
-            document_languages=task.document_metadata.languages,
-            document_md5_sum=task.document_md5_sum,
-            document_content_type=task.document_content_type,
-            document_cdn_object=task.document_cdn_object,
-            document_source_url=task.document_metadata.source_url,
-        )
+        search_weights_ref=search_weights_ref,
+        family_name=task.document_name,
+        family_name_index=task.document_name,
+        family_description=task.document_description,
+        family_description_index=task.document_description,
+        family_description_embedding=embeddings[0].tolist(),
+        family_import_id=task.document_metadata.family_import_id,
+        family_slug=task.document_metadata.family_slug,
+        family_publication_ts=task.document_metadata.publication_ts.isoformat(),
+        family_publication_year=task.document_metadata.publication_ts.year,
+        family_category=task.document_metadata.category,
+        family_geography=task.document_metadata.geography,
+        family_source=task.document_metadata.source,
+        document_import_id=task.document_id,
+        document_slug=task.document_slug,
+        document_languages=task.document_metadata.languages,
+        document_md5_sum=task.document_md5_sum,
+        document_content_type=task.document_content_type,
+        document_cdn_object=task.document_cdn_object,
+        document_source_url=task.document_metadata.source_url,
+    )
 
 
 def build_vespa_document_passage(
-        family_document_id,
-        search_weights_ref,
-        text_block,
-        embedding
-    ) -> VespaDocumentPassage:
+    family_document_id,
+    search_weights_ref,
+    text_block,
+    text_block_window: str,
+    embedding_bge_small,
+    embedding_bge_base,
+    embedding_distilbert_tas_b,
+    embedding_distilbert_dot_v5,
+) -> VespaDocumentPassage:
     fam_doc_ref = f"id:{_NAMESPACE}:family_document::{family_document_id}"
     return VespaDocumentPassage(
         family_document_ref=fam_doc_ref,
         search_weights_ref=search_weights_ref,
-        text_block="\n".join(text_block.text),
+        text_block=get_text_from_text_block(text_block),
+        text_block_window=text_block_window,
         text_block_id=text_block.text_block_id,
         text_block_type=str(text_block.type),
         text_block_page=(
-            text_block.page_number
-            if isinstance(text_block, PDFTextBlock)
-            else None
+            text_block.page_number if isinstance(text_block, PDFTextBlock) else None
         ),
         text_block_coords=(
             text_block.coords if isinstance(text_block, PDFTextBlock) else None
         ),
-        text_embedding=embedding.tolist(),
+        text_embedding_bge_small=embedding_bge_small.tolist(),
+        text_embedding_bge_base=embedding_bge_base.tolist(),
+        text_embedding_distilbert_base_tas_b=embedding_distilbert_tas_b.tolist(),
+        text_embedding_distilbert_dot_v5=embedding_distilbert_dot_v5.tolist(),
     )
 
 
-def get_existing_passage_ids(vespa: Vespa, family_doc_id: DocumentID, offset: int = 0) -> list[str]:
+def get_existing_passage_ids(
+    vespa: Vespa, family_doc_id: DocumentID, offset: int = 0
+) -> list[str]:
     """
     Retrieves all text blocks associated with a document
-    
+
     In vespa terminology this means all document_passages for a given family_document
     """
     vespa_family_doc_id = f"id:{_NAMESPACE}:family_document::{family_doc_id}"
@@ -168,7 +184,7 @@ def get_existing_passage_ids(vespa: Vespa, family_doc_id: DocumentID, offset: in
 
     existing_ids = []
     response = vespa.query(
-        body = {
+        body={
             "yql": """
                 select documentid from sources document_passage
                 where family_document_ref contains phrase(@family_doc_id)
@@ -191,7 +207,9 @@ def get_existing_passage_ids(vespa: Vespa, family_doc_id: DocumentID, offset: in
     return existing_ids
 
 
-def determine_stray_ids(existing_doc_passage_ids: list[str], new_passage_ids: list[str]) -> list[str]:
+def determine_stray_ids(
+    existing_doc_passage_ids: list[str], new_passage_ids: list[str]
+) -> list[str]:
     return list(set(existing_doc_passage_ids) - set(new_passage_ids))
 
 
@@ -199,9 +217,7 @@ def remove_ids(vespa: Vespa, stray_ids: list[str]):
     _LOGGER.critical(f"Removing stray ids following doc changes: {stray_ids}")
     for stray_id in stray_ids:
         vespa.delete_data(
-            schema=DOCUMENT_PASSAGE_SCHEMA,
-            data_id=stray_id,
-            namespace=_NAMESPACE
+            schema=DOCUMENT_PASSAGE_SCHEMA, data_id=stray_id, namespace=_NAMESPACE
         )
 
 
@@ -240,18 +256,33 @@ def get_document_generator(
     physical_document_count = 0
     for path in paths:
         task = ParserOutput.model_validate_json(path.read_text())
- 
+
         task = filter_on_block_type(
             input=task, remove_block_types=config.BLOCKS_TO_FILTER
         )
 
-        task_array_file_path = cast(
-            Path, embedding_dir_as_path / f"{task.document_id}.npy"
-        )
-        embeddings = read_npy_file(task_array_file_path)
+        embeddings_by_model_slug = dict()
+
+        for model_slug in [
+            "baai-bge-small-en-v1-5",
+            "baai-bge-base-en-v1-5",
+            "msmarco-distilbert-base-tas-b",
+            "msmarco-distilbert-dot-v5",
+        ]:
+            task_array_file_path = cast(
+                Path, embedding_dir_as_path / f"{task.document_id}__{model_slug}.npy"
+            )
+            embeddings_by_model_slug[model_slug] = read_npy_file(task_array_file_path)
 
         family_document_id = DocumentID(task.document_metadata.import_id)
-        family_document = build_vespa_family_document(task, embeddings, search_weights_ref)
+        # NOTE we don't use the document description embedding for RAG, so here we'll just use the model that we already use in product
+        family_document = build_vespa_family_document(
+            task,
+            embeddings_by_model_slug[
+                "msmarco-distilbert-dot-v5",
+            ],
+            search_weights_ref,
+        )
 
         yield FAMILY_DOCUMENT_SCHEMA, family_document_id, family_document.model_dump()
         physical_document_count += 1
@@ -273,15 +304,61 @@ def get_document_generator(
         existing_doc_passage_ids = get_existing_passage_ids(vespa, family_document_id)
 
         new_passage_ids = []
-        
+
+        embeddings_baai_small = embeddings_by_model_slug["baai-bge-small-en-v1-5"]
+        embeddings_baai_base = embeddings_by_model_slug["baai-bge-base-en-v1-5"]
+        embeddings_distilbert_tas_b = embeddings_by_model_slug[
+            "msmarco-distilbert-base-tas-b"
+        ]
+        embeddings_distilbert_dot_v5 = embeddings_by_model_slug[
+            "msmarco-distilbert-dot-v5"
+        ]
+
         # Note that the first embedding item is the doc description
         # The rest are text blocks
-        for document_passage_idx, (text_block, embedding) in enumerate(
-            zip(text_blocks, embeddings[1:, :]) 
+        for document_passage_idx, (
+            text_block,
+            embedding_baai_small,
+            embedding_baai_base,
+            embedding_distilbert_tas_b,
+            embedding_distilbert_dot_v5,
+        ) in enumerate(
+            zip(
+                text_blocks,
+                embeddings_baai_small[1:, :],
+                embeddings_baai_base[1:, :],
+                embeddings_distilbert_tas_b[1:, :],
+                embeddings_distilbert_dot_v5[1:, :],
+            )
         ):
             document_psg_id = DocumentID(f"{task.document_id}.{document_passage_idx}")
             new_passage_ids.append(document_psg_id)
-            document_passage = build_vespa_document_passage(family_document_id, search_weights_ref, text_block, embedding)
+
+            if document_passage_idx == 0:
+                idxs_in_window = [document_passage_idx, document_passage_idx + 1]
+            elif document_passage_idx == len(text_blocks) - 1:
+                idxs_in_window = [document_passage_idx - 1, document_passage_idx]
+            else:
+                idxs_in_window = [
+                    document_passage_idx - 1,
+                    document_passage_idx,
+                    document_passage_idx + 1,
+                ]
+
+            text_block_window = "\n".join(
+                get_text_from_text_block(text_blocks[i]) for i in idxs_in_window
+            )
+
+            document_passage = build_vespa_document_passage(
+                family_document_id,
+                search_weights_ref,
+                text_block,
+                text_block_window,
+                embedding_bge_small=embedding_baai_small,
+                embedding_bge_base=embedding_baai_base,
+                embedding_distilbert_tas_b=embedding_distilbert_tas_b,
+                embedding_distilbert_dot_v5=embedding_distilbert_dot_v5,
+            )
             yield DOCUMENT_PASSAGE_SCHEMA, document_psg_id, document_passage.model_dump()
         # Cleanup stray docs
         stray_ids = determine_stray_ids(existing_doc_passage_ids, new_passage_ids)
@@ -324,6 +401,7 @@ def _check_vespa_certs():
 
     return str(key_location), str(cert_location)
 
+
 def _get_vespa_instance() -> Vespa:
     """
     Creates a Vespa instance based on validated config values.
@@ -341,7 +419,7 @@ def _get_vespa_instance() -> Vespa:
         _LOGGER.info("Running in dev mode, authentication will not be used")
     else:
         key_location, cert_location = _check_vespa_certs()
-    
+
     _LOGGER.info(f"Indexing into: {config.VESPA_INSTANCE_URL}")
     return Vespa(
         url=config.VESPA_INSTANCE_URL,
@@ -353,7 +431,9 @@ def _get_vespa_instance() -> Vespa:
 def _handle_feed_error(response: VespaResponse, id: str) -> None:
     """Callback for vespa feed"""
     if not response.is_successful():
-        raise VespaIndexError(f"Indexing Failed on document with id: {id}, body: {response.json}")
+        raise VespaIndexError(
+            f"Indexing Failed on document with id: {id}, body: {response.json}"
+        )
 
 
 @retry(wait=wait_exponential(multiplier=10), stop=stop_after_attempt(10))

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,7 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def build_indexer_input_path(indexer_input_dir: str, s3: bool) -> Union[S3Path, Path]:
-    _LOGGER.info(f"Tasks will be retrieved from {'s3' if s3 else 'local'}: {indexer_input_dir}")
+    _LOGGER.info(
+        f"Tasks will be retrieved from {'s3' if s3 else 'local'}: {indexer_input_dir}"
+    )
     if s3:
         indexer_input_path = cast(S3Path, S3Path(indexer_input_dir))
     else:
@@ -46,7 +48,7 @@ def get_index_paths(
 
     paths = []
     doc_ids = []
-    for i, path in enumerate(list(indexer_input_path.glob("*.json")), 1):        
+    for i, path in enumerate(list(indexer_input_path.glob("*.json")), 1):
         doc_id = path.stem
         if files_to_index and (doc_id not in files_to_index):
             continue
@@ -98,7 +100,7 @@ def filter_blocks(
 
 def filter_on_block_type(
     input: ParserOutput, remove_block_types: list[str]
-) -> Sequence[ParserOutput]:
+) -> ParserOutput:
     """
     Filter a sequence of IndexerInputs to remove unwanted TextBlocks.
 
@@ -115,11 +117,11 @@ def filter_on_block_type(
             remove_block_types.remove(_filter)
 
     return replace_text_blocks(
-            block=input,
-            new_text_blocks=filter_blocks(
-                indexer_input=input, remove_block_types=remove_block_types
-            ),
-        )
+        block=input,
+        new_text_blocks=filter_blocks(
+            indexer_input=input, remove_block_types=remove_block_types
+        ),
+    )
 
 
 def read_npy_file(file_path: Path) -> Any:

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,6 +12,11 @@ from cpr_data_access.parser_models import BlockType, ParserOutput, TextBlock
 _LOGGER = logging.getLogger(__name__)
 
 
+def get_text_from_text_block(text_block: TextBlock) -> str:
+    """Get the text from a TextBlock."""
+    return "\n".join(text_block.text)
+
+
 def build_indexer_input_path(indexer_input_dir: str, s3: bool) -> Union[S3Path, Path]:
     _LOGGER.info(
         f"Tasks will be retrieved from {'s3' if s3 else 'local'}: {indexer_input_dir}"

--- a/tests/src/test_vespa.py
+++ b/tests/src/test_vespa.py
@@ -38,7 +38,11 @@ def test_build_vespa_document_passage():
         family_document_id="doc.1.1",
         search_weights_ref="id:doc_search:weight::default",
         text_block=text_block,
-        embedding=np.array([-0.11900115, 0.17448892]),
+        text_block_window="window",
+        embedding_bge_small=np.array([-0.11900115, 0.17448892]),
+        embedding_bge_base=np.array([-0.11900115, 0.17448892]),
+        embedding_distilbert_dot_v5=np.array([-0.11900115, 0.17448892]),
+        embedding_distilbert_tas_b=np.array([-0.11900115, 0.17448892]),
     )
     VespaDocumentPassage.model_validate(model)
 
@@ -50,7 +54,9 @@ def test_get_existing_passage_ids__new_doc(test_vespa):
     assert not existing_ids
 
 
-@pytest.mark.usefixtures("cleanup_test_vespa_before", "preload_fixtures", "cleanup_test_vespa_after")
+@pytest.mark.usefixtures(
+    "cleanup_test_vespa_before", "preload_fixtures", "cleanup_test_vespa_after"
+)
 def test_get_existing_passage_ids__existing_doc(test_vespa):
     family_doc_id = "CCLW.executive.10014.4470"
     start = get_existing_passage_ids(vespa=test_vespa, family_doc_id=family_doc_id)
@@ -112,7 +118,6 @@ def test_get_document_generator(test_vespa):
     assert EXPECTED_DOCUMENTS == len(paths)
     assert EXPECTED_PASSAGES == len(fixture_text_blocks)
 
-
     schemas = []
     ids = []
     document_passage_ids = []
@@ -134,7 +139,6 @@ def test_get_document_generator(test_vespa):
             VespaFamilyDocument.model_validate(data)
         else:
             pytest.exit(f"Unexpected schema: {schema}")
-
 
     # Test schemas
     assert len(set(schemas)) == len(_SCHEMAS_TO_PROCESS)


### PR DESCRIPTION
Note this implementation isn't that smooth - it'd be nice to have a shared config of model names with the embeddings generation step, and use this config here instead. Although I don't think it matters too much, because the model names are hardcoded into the Vespa schema anyway.

Also includes a typing fix, which made me realise that `src/utils.py` is pretty broken in terms of typing (and was before I made any of these changes). I didn't fix this in this PR as I didn't want to break anything.